### PR TITLE
feature(commands, scripts): Add commands and scripts

### DIFF
--- a/Commands/Miscallaneous/ping.js
+++ b/Commands/Miscallaneous/ping.js
@@ -1,0 +1,25 @@
+import pkg from 'discord.js';
+const { SlashCommandBuilder, EmbedBuilder, Client, Interaction } = pkg;
+
+const pingCommand = {
+    data: new SlashCommandBuilder()
+        .setName("ping")
+        .setDescription("Displays the latency of the bot."),
+
+    /**
+     * Executes the ping command.
+     * @param {Client} client The instance of the Discord bot
+     * @param {Interaction} interaction The command interaction
+     */
+    async execute(client, interaction) {
+        const sent = await interaction.reply({ content: "Pinging...", fetchResponse: true });
+        const roundtripLatency = sent.createdTimestamp - interaction.createdTimestamp;
+        const responseEmbed = new EmbedBuilder()
+            .setColor('Green')
+            .setDescription(`API latency: ${client.ws.ping}ms\nRoundtrip latency: ${roundtripLatency}ms`);
+
+        interaction.editReply({ content: "Ping done!", embeds: [responseEmbed] });
+    }
+}
+
+export default pingCommand;

--- a/Commands/Organisatory/cleanup.js
+++ b/Commands/Organisatory/cleanup.js
@@ -1,0 +1,96 @@
+import pkg from 'discord.js';
+const { SlashCommandBuilder, Channel, Client, Interaction } = pkg;
+import config from '../../config.json' with { type: 'json' };
+import moment from 'moment';
+
+const cleanupCommand = {
+    data: new SlashCommandBuilder()
+        .setName("cleanup")
+        .setDescription("Cleans up #oo-calendar and posts new time messages."),
+
+    /**
+     * Executes the cleanup command.
+     * @param {Client} client The instance of the Discord Bot
+     * @param {Interaction} interaction The command interaction
+     * @returns 
+     */
+    async execute(client, interaction) {
+        // Check if user has member role
+        if (!interaction.member.roles.cache.find(role => role.id === config.roles.team.id)) return interaction.reply(`You are not a member of ${config.teamName}, so you may not use this command!`);
+
+        await interaction.deferReply();
+
+        let channelId = config.channels.teamCalendar.id;
+        let channel = await interaction.guild.channels.fetch(channelId);
+
+        await prepareChannel(channel);
+        
+        interaction.editReply(`Cleaned up #${config.channels.teamCalendar.name}!`);
+    }
+}
+
+/**
+ * Cleans up the specified channel and posts new time messages with pre-appended reactions for easy availability checking.
+ * @param {Channel} channel The channel to prepare
+ */
+const prepareChannel = async (channel) => {
+    console.info(`Cleaning up channel #${channel.name}...`);
+    await channel.bulkDelete(50, false);
+
+    // Get the following Monday's date in UTC and set the time to 00:00:00, then convert to Unix timestamp
+    let unix = moment().utc().isoWeekday(8).startOf('day').unix()
+    let message = await channel.send(`Monday, <t:${unix}:D>`);
+    await message.react('✅');
+    await message.react('❔');
+    await message.react('❕');
+    await message.react('❌');
+
+    unix += 86400;
+    let message2 = await channel.send(`Tuesday, <t:${unix}:D>`);
+    await message2.react('✅');
+    await message2.react('❔');
+    await message2.react('❕');
+    await message2.react('❌');
+
+    unix += 86400;
+    let message3 = await channel.send(`Wednesday, <t:${unix}:D>`);
+    await message3.react('✅');
+    await message3.react('❔');
+    await message3.react('❕');
+    await message3.react('❌');
+    
+    unix += 86400;
+    let message4 = await channel.send(`Thursday, <t:${unix}:D>`);
+    await message4.react('✅');
+    await message4.react('❔');
+    await message4.react('❕');
+    await message4.react('❌');
+    
+    unix += 86400;
+    let message5 = await channel.send(`Friday, <t:${unix}:D>`);
+    await message5.react('✅');
+    await message5.react('❔');
+    await message5.react('❕');
+    await message5.react('❌');
+
+    unix += 86400;
+    let message6 = await channel.send(`Saturday, <t:${unix}:D>`);
+    await message6.react('✅');
+    await message6.react('❔');
+    await message6.react('❕');
+    await message6.react('❌');
+    
+    unix += 86400;
+    let message7 = await channel.send(`Sunday, <t:${unix}:D>`);
+    await message7.react('✅');
+    await message7.react('❔');
+    await message7.react('❕');
+    await message7.react('❌');
+
+    await channel.send(`<@&${config.roles.team.id}> Please check your availability for the next week!\n**__Legend__**:\n✅ Available\n❔ Maybe\n❕ Can play as a substitution\n❌ Not available`);
+    console.info(`Finished cleaning up channel #${channel.name}!`);
+}
+
+export default cleanupCommand;
+
+export { prepareChannel };

--- a/Events/interactionCreate.js
+++ b/Events/interactionCreate.js
@@ -1,0 +1,38 @@
+import pkg from 'discord.js';
+const { Events, Client, Interaction } = pkg;
+import config from '../config.json' with { type: 'json' };
+
+const interactionCreateHandler = {
+    name: Events.InteractionCreate,
+    /**
+     * Executes the desired command upon interaction creation.
+     * @param {Client} client The instance of the Discord bot
+     * @param {Interaction} interaction The interaction that was created
+     */
+    async execute(client, interaction) {
+        // Ignore if interaction isn't a slash command
+        if (!interaction.isChatInputCommand()) return;
+
+        // Find used command in command collection
+        const command = interaction.client.commands.get(interaction.commandName);
+
+        // Output an error if no command is found
+        if (!command) {
+            console.error(`No command matching ${interaction.commandName} was found.`);
+            return;
+        }
+
+        // Attempt to run the used command
+        try {
+            console.info(`Executing command ${interaction.commandName}...`);
+            await command.execute(client, interaction);
+        } catch (error) {
+            console.error(`Command ${interaction.commandName} ran into an error:\n${error.message}`);
+            interaction.reply(error.message ? `Command ${interaction.commandName} ran into an error:\n${error.message}` : "An unknown error has occurred.")
+            let user = client.users.cache.get(config.users.haze.id);
+            user.send(error.message ? `Command ${interaction.commandName} ran into an error:\n${error.message}` : "An unknown error has occurred.");
+        }
+    }
+};
+
+export default interactionCreateHandler;

--- a/Events/ready.js
+++ b/Events/ready.js
@@ -1,0 +1,80 @@
+import pkg from 'discord.js';
+const { Events, Client } = pkg;
+import { CronJob } from 'cron';
+import { prepareChannel } from '../Commands/Organisatory/cleanup.js';
+import config from '../config.json' with { type: 'json' };
+
+const clientReady = {
+    name: Events.ClientReady,
+    once: true,
+    /**
+     * Runs required tasks upon startup of the bot.
+     * @param {Client} client The instance of the Discord bot
+     */
+    async execute(client) {
+        // CronJob argument info: Seconds - Minutes - Hours - Day - Month - Weekday
+        // Runs daily at 2pm UTC to remind users to schedule their training time
+        let scheduledMessage = new CronJob('00 00 15 * * *', async () => {
+            console.info("Running Cron job 'scheduledMessage'...");
+            const guild = client.guilds.cache.get(config.guildId);
+            const teamCalendar = guild.channels.cache.get(config.channels.teamCalendar.id);
+            const teamChat = guild.channels.cache.get(config.channels.teamChat.id);
+
+            let today = new Date();
+            let dayOfWeek = today.getDay() - 1;
+
+            let messages = Array.from((await teamCalendar.messages.fetch({ limit: 50 })).values()).reverse();
+            let index = dayOfWeek;
+
+            if (index < 0) index = 6;
+
+            let lfgMessage = messages[index];
+            let pingArray = [];
+
+            // Get all users who reacted with ❔ or ✅
+            for (let reaction of lfgMessage.reactions.cache.values()) {
+                const emojiName = reaction._emoji.name;
+                if (emojiName != '❔' && emojiName != '✅') continue;
+
+                const reactionUsers = await reaction.users.fetch();
+
+                for (let user of reactionUsers.values()) {
+                    if (user.bot === true) continue;
+                    pingArray.push(user);
+                }
+            }
+
+            if (notSureArray.length === 0) return;
+
+            let reminderMessage = "";
+            for (let member of notSureArray.values()) {
+                reminderMessage += `<@!${member.id}>\n`;
+            }
+
+            reminderMessage += "Reminder to schedule for today's training time!";
+            teamChat.send(reminderMessage);
+            console.info("Cron job 'scheduledMessage' finished!");
+        });
+
+        // Runs an automated cleanup of the team calendar channel every Sunday at 10pm UTC
+        let scheduledCleanup = new CronJob('00 00 23 * * 7', async () => {
+            console.info("Running Cron job 'scheduledCleanup'...");
+            const guild = client.guilds.cache.get(config.guildId);
+            const lfgChannel = guild.channels.cache.get(config.channels.teamCalendar.id);
+            await prepareChannel(lfgChannel);
+            console.info("Cron job 'scheduledCleanup' finished!");
+        });
+
+        scheduledMessage.start();
+        scheduledCleanup.start();
+        console.info("Cron jobs started!");
+
+        client.user.setPresence({
+            status: 'online'
+        });
+
+        console.log("Client is ready and running!");
+    }
+}
+
+export default clientReady;

--- a/Scripts/deploy-commands.js
+++ b/Scripts/deploy-commands.js
@@ -1,0 +1,38 @@
+// This script deploys all application (/) commands to the bot using the Discord API.
+// It reads command files from the Commands folder, prepares the commands in JSON format, and sends them to the Discord API.
+import { REST, Routes } from 'discord.js';
+import config from '../config.json' with { type: 'json' };
+import fs from 'node:fs';
+
+const __dirname = import.meta.dirname;
+const commands = [];
+
+// Fetch all command files located in the Commands folder
+const commandFiles = fs.readdirSync(`${__dirname}/../Commands`, { recursive: true }).filter(file => file.endsWith('.js'));
+
+// Fetch Slash commands in JSON format for each file
+for (const file of commandFiles) {
+    const { default: command } = await import(`file://${__dirname}/../Commands/${file}`);
+    commands.push(command.data.toJSON());
+    console.info(`Found command: ${command.data.name}`);
+}
+
+// Create and prepare an instance of the REST module
+const rest = new REST({ version: '10' }).setToken(config.token);
+
+// Deploy commands
+(async () => {
+    try {
+        console.info(`Started refreshing ${commands.length} application (/) commands.`);
+
+        // Use PUT method to fully refresh all commands
+        const data = await rest.put(
+            Routes.applicationGuildCommands(config.clientId, config.guildId),
+            { body: commands },
+        );
+
+        console.info(`Successfully reloaded ${data.length} application (/) commands.`);
+    } catch (error) {
+        console.error('Error deploying application (/) commands:', error);
+    }
+})();

--- a/Scripts/remove-commands.js
+++ b/Scripts/remove-commands.js
@@ -1,0 +1,32 @@
+// This script removes all application commands from the bot. It is useful for cleaning up commands that are no longer needed or for resetting the command list.
+// It uses the Discord API to delete all commands associated with the bot's client ID.
+import { REST, Routes } from 'discord.js';
+import config from '../config.json' with { type: 'json' };
+
+const commands = [];
+
+// Create and prepare an instance of the REST module
+const rest = new REST({ version: '10' }).setToken(config.token);
+
+(async () => {
+    try {
+        // Remove global commands
+        console.info(`Started removing global application (/) commands.`);
+        await rest.put(
+            Routes.applicationCommands(config.clientId),
+            { body: commands },
+        );
+        console.info(`Successfully removed global application (/) commands.`);
+
+        // Remove guild commands
+        console.info(`Started removing guild application (/) commands.`);
+        await rest.put(
+            Routes.applicationGuildCommands(config.clientId, config.guildId),
+            { body: commands },
+        );
+        console.info(`Successfully removed guild application (/) commands.`);
+        
+    } catch (error) {
+        console.error('Error removing application (/) commands:', error);
+    }
+})();

--- a/index.js
+++ b/index.js
@@ -1,0 +1,47 @@
+import pkg from 'discord.js';
+const { Client, GatewayIntentBits, Collection } = pkg;
+import fs from 'node:fs';
+import path from 'node:path';
+import config from './config.json' with { type: 'json' };
+
+// Client initialization
+const client = new Client({ intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessageTyping, GatewayIntentBits.GuildMessages, GatewayIntentBits.GuildMembers, GatewayIntentBits.GuildMessageReactions] });
+const __dirname = import.meta.dirname;
+
+// Load event files
+const eventsPath = path.join(__dirname, 'Events');
+const eventFiles = fs.readdirSync(eventsPath).filter(file => file.endsWith('.js'));
+
+// Run called commands
+for (const file of eventFiles) {
+    const filePath = path.join(eventsPath, file);
+    const { default: event } = await import(`file:\\\\${filePath}`);
+    if (event.once) {
+        client.once(event.name, (...args) => event.execute(...args));
+    } else {
+        client.on(event.name, (...args) => event.execute(client, ...args));
+    }
+}
+
+client.commands = new Collection();
+
+// Load commands from Command folder
+const commandsPath = path.join(__dirname, 'Commands');
+const commandFiles = fs.readdirSync(commandsPath, { recursive: true }).filter(file => file.endsWith('.js'));
+
+// Add commands to command Collection
+for (const file of commandFiles) {
+    const filePath = path.join(commandsPath, file);
+    const { default: command } = await import(`file:\\\\${filePath}`);
+
+    // Set new item in command collection
+    // key: name, value: exported module
+    if ('data' in command && 'execute' in command) {
+        client.commands.set(command.data.name, command);
+    } else {
+        console.log(`[WARNING] The command at ${filePath} is missing a required "data" or "execute" property.`);
+    }
+}
+
+// Log in to Discord using the token
+client.login(config.token);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,316 @@
+{
+  "name": "Tao-Blue",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "cron": "^4.3.0",
+        "discord.js": "^14.19.2",
+        "moment": "^2.30.1"
+      }
+    },
+    "node_modules/@discordjs/builders": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.11.1.tgz",
+      "integrity": "sha512-2zDAVuoeAkdv0YQzYKO8vZfaDfB+1KZ60ymBKtD7QDpsh6lzAnQSUBLqeRkhlons6BT9+yRctOh9fPy94w6kDA==",
+      "dependencies": {
+        "@discordjs/formatters": "^0.6.1",
+        "@discordjs/util": "^1.1.1",
+        "@sapphire/shapeshift": "^4.0.0",
+        "discord-api-types": "^0.38.1",
+        "fast-deep-equal": "^3.1.3",
+        "ts-mixer": "^6.0.4",
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/collection": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
+      "integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==",
+      "engines": {
+        "node": ">=16.11.0"
+      }
+    },
+    "node_modules/@discordjs/formatters": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.1.tgz",
+      "integrity": "sha512-5cnX+tASiPCqCWtFcFslxBVUaCetB0thvM/JyavhbXInP1HJIEU+Qv/zMrnuwSsX3yWH2lVXNJZeDK3EiP4HHg==",
+      "dependencies": {
+        "discord-api-types": "^0.38.1"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.5.0.tgz",
+      "integrity": "sha512-PWhchxTzpn9EV3vvPRpwS0EE2rNYB9pvzDU/eLLW3mByJl0ZHZjHI2/wA8EbH2gRMQV7nu+0FoDF84oiPl8VAQ==",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.1",
+        "@discordjs/util": "^1.1.1",
+        "@sapphire/async-queue": "^1.5.3",
+        "@sapphire/snowflake": "^3.5.3",
+        "@vladfrangu/async_event_emitter": "^2.4.6",
+        "discord-api-types": "^0.38.1",
+        "magic-bytes.js": "^1.10.0",
+        "tslib": "^2.6.3",
+        "undici": "6.21.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/util": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.1.1.tgz",
+      "integrity": "sha512-eddz6UnOBEB1oITPinyrB2Pttej49M9FZQY8NxgEvc3tq6ZICZ19m70RsmzRdDHk80O9NoYN/25AqJl8vPVf/g==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.2.tgz",
+      "integrity": "sha512-dyfq7yn0wO0IYeYOs3z79I6/HumhmKISzFL0Z+007zQJMtAFGtt3AEoq1nuLXtcunUE5YYYQqgKvybXukAK8/w==",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.0",
+        "@discordjs/rest": "^2.5.0",
+        "@discordjs/util": "^1.1.0",
+        "@sapphire/async-queue": "^1.5.2",
+        "@types/ws": "^8.5.10",
+        "@vladfrangu/async_event_emitter": "^2.2.4",
+        "discord-api-types": "^0.38.1",
+        "tslib": "^2.6.2",
+        "ws": "^8.17.0"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@sapphire/async-queue": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
+      "integrity": "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@sapphire/shapeshift": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz",
+      "integrity": "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=v16"
+      }
+    },
+    "node_modules/@sapphire/snowflake": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
+      "integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.6.2.tgz",
+      "integrity": "sha512-R/BdP7OxEMc44l2Ex5lSXHoIXTB2JLNa3y2QISIbr58U/YcsffyQrYW//hZSdrfxrjRZj3GcUoxMPGdO8gSYuw=="
+    },
+    "node_modules/@types/node": {
+      "version": "22.15.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.3.tgz",
+      "integrity": "sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw==",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@vladfrangu/async_event_emitter": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.6.tgz",
+      "integrity": "sha512-RaI5qZo6D2CVS6sTHFKg1v5Ohq/+Bo2LZ5gzUEwZ/WkHhwtGTCB/sVLw8ijOkAUxasZ+WshN/Rzj4ywsABJ5ZA==",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/cron": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-4.3.0.tgz",
+      "integrity": "sha512-ciiYNLfSlF9MrDqnbMdRWFiA6oizSF7kA1osPP9lRzNu0Uu+AWog1UKy7SkckiDY2irrNjeO6qLyKnXC8oxmrw==",
+      "dependencies": {
+        "@types/luxon": "~3.6.0",
+        "luxon": "~3.6.0"
+      },
+      "engines": {
+        "node": ">=18.x"
+      }
+    },
+    "node_modules/discord-api-types": {
+      "version": "0.38.2",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.2.tgz",
+      "integrity": "sha512-GAPY1/Kv3aqEoBYgUYXB2tHdWJCZXfytlCzxZ4QMQ1/TIQn1JI+xUOukehl4iEa9m7fCURnMIOpOxpaTWqzX2w=="
+    },
+    "node_modules/discord.js": {
+      "version": "14.19.2",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.19.2.tgz",
+      "integrity": "sha512-L/ivhVefzzRcChHJSaGYsgA4Uqx6or2sst5JZ/ft9OBwrj8OJIzrrcutlkHnm/hlI0Hrm3es62TRVksU8VUqrg==",
+      "dependencies": {
+        "@discordjs/builders": "^1.11.1",
+        "@discordjs/collection": "1.5.3",
+        "@discordjs/formatters": "^0.6.1",
+        "@discordjs/rest": "^2.5.0",
+        "@discordjs/util": "^1.1.1",
+        "@discordjs/ws": "^1.2.2",
+        "@sapphire/snowflake": "3.5.3",
+        "discord-api-types": "^0.38.1",
+        "fast-deep-equal": "3.1.3",
+        "lodash.snakecase": "4.1.1",
+        "magic-bytes.js": "^1.10.0",
+        "tslib": "^2.6.3",
+        "undici": "6.21.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="
+    },
+    "node_modules/luxon": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.6.1.tgz",
+      "integrity": "sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/magic-bytes.js": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.12.1.tgz",
+      "integrity": "sha512-ThQLOhN86ZkJ7qemtVRGYM+gRgR8GEXNli9H/PMvpnZsE44Xfh3wx9kGJaldg314v85m+bFW6WBMaVHJc/c3zA=="
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ts-mixer": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
+      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA=="
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
+    "node_modules/undici": {
+      "version": "6.21.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.1.tgz",
+      "integrity": "sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
+    },
+    "node_modules/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "type": "module",
+  "dependencies": {
+    "cron": "^4.3.0",
+    "discord.js": "^14.19.2",
+    "moment": "^2.30.1"
+  },
+  "scripts": {
+    "start": "node index.js"
+  }
+}


### PR DESCRIPTION
# Changes
- Added required file structure
- Added Scripts for easier command deployment and removal
  - `deploy-commands.js`: Fetches and sends all commands in the directory and subdirectories of `/Command/` to Discord's API endpoint. In this use-case, the commands are set to be bound to the guild.
  - `remove-commands.js`: Sends an empty command list to Discord's API endpoint to remove all application (/) commands
- Added commands
  - `ping.js`: Gets the API latency and roundtrip latency. Usable by everyone.
  - `cleanup.js`: Cleans up the team calendar channel to allow for availability reactions for the coming week, starting with Monday. Only usable by server members with the team role.
- Added various logging statements across the code
- Added npm script to start the bot
- Added events
  - `ready.js`: Prepares everything the bot needs on startup, including two (2) cron jobs:
    - `scheduledMessage`: Sends a message in the team chat every day at 2pm UTC, pinging everyone that reacted with checkmark or question mark.
    - `scheduledCleanup`: Automatically runs the code for the `/cleanup` command on Sundays at 10pm UTC.
  - `interactionCreate.js`: Creates an interaction and runs the requested command when receiving an application (/) command